### PR TITLE
Add end-to-end NLP mental-health risk prediction pipeline with local Streamlit app

### DIFF
--- a/mental_health_risk_app/README.md
+++ b/mental_health_risk_app/README.md
@@ -1,0 +1,34 @@
+# Mental Health Risk Prediction (Local, End-to-End)
+
+This module adds an end-to-end NLP workflow for estimating depression/stress risk from user text.
+
+## What is included
+- Dataset ingestion and preprocessing (cleaning, tokenization, sentiment, emotion proxy features).
+- Class imbalance handling through class-weighted training.
+- Baseline models: TF-IDF + Logistic Regression / Linear SVM.
+- Transformer fine-tuning pipeline (DistilBERT; can be swapped to BERT/RoBERTa).
+- Evaluation: Precision, Recall, F1, ROC-AUC, confusion matrix.
+- Interpretability: SHAP top tokens for baseline, attention-token highlights for transformer.
+- Fairness check: subgroup recall gap.
+- Temporal modeling: exponential moving trend per user.
+- Streamlit local app with confidence score, secure hash-based logging, and drift monitoring.
+
+## Ethical safeguards
+- This is **not** a medical diagnostic tool.
+- Predictions are probabilistic triage signals and must be reviewed by qualified humans.
+- Use local inference and hashed identifiers in logs to reduce privacy risk.
+
+## Quick start
+```bash
+pip install -r mental_health_risk_app/requirements.txt
+python mental_health_risk_app/train.py --data mental_health_risk_app/data/sample_mental_health.csv --baseline logreg
+streamlit run mental_health_risk_app/app.py
+```
+
+## Data format
+CSV columns expected:
+- `text` (required)
+- `label` (required; binary or multi-class)
+- `user_id` (optional but recommended for temporal trend)
+- `timestamp` (optional but recommended for temporal trend)
+- `group` (optional subgroup for fairness analysis)

--- a/mental_health_risk_app/app.py
+++ b/mental_health_risk_app/app.py
@@ -1,0 +1,108 @@
+import hashlib
+from datetime import datetime
+
+import joblib
+import numpy as np
+import pandas as pd
+import streamlit as st
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+from src.analysis import monitor_drift
+from src.config import (
+    BASELINE_MODEL_PATH,
+    LABEL_COLUMN,
+    LOG_DIR,
+    PREDICTION_LOG_PATH,
+    TEXT_COLUMN,
+    TRANSFORMER_DIR,
+    USER_ID_COLUMN,
+)
+from src.modeling import prepare_features
+from src.preprocess import preprocess_frame
+
+st.set_page_config(page_title="Mental Health Risk Estimator", layout="wide")
+st.title("NLP-based Mental Health Risk Prediction (Local Inference)")
+st.warning(
+    "This tool is for educational triage support only and is NOT a medical diagnostic system. "
+    "If someone may be in immediate danger, contact local emergency services or a licensed mental health professional."
+)
+
+model_choice = st.sidebar.selectbox("Model", ["Baseline TF-IDF", "Transformer"])
+confidence_threshold = st.sidebar.slider("Risk alert threshold", 0.5, 0.95, 0.7, 0.01)
+
+user_id = st.text_input("User ID (optional)", "anonymous")
+text = st.text_area("Enter a journal entry or social post", height=220)
+
+
+def secure_log(entry: dict):
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    row = pd.DataFrame([entry])
+    if PREDICTION_LOG_PATH.exists():
+        row.to_csv(PREDICTION_LOG_PATH, mode="a", header=False, index=False)
+    else:
+        row.to_csv(PREDICTION_LOG_PATH, index=False)
+
+
+if st.button("Predict risk"):
+    if not text.strip():
+        st.error("Please provide text.")
+    else:
+        frame = pd.DataFrame([{TEXT_COLUMN: text, LABEL_COLUMN: "unknown", USER_ID_COLUMN: user_id}])
+        frame = preprocess_frame(frame)
+
+        if model_choice == "Baseline TF-IDF":
+            if not BASELINE_MODEL_PATH.exists():
+                st.error("Baseline model artifacts not found. Run training script first.")
+                st.stop()
+            model = joblib.load(BASELINE_MODEL_PATH)
+            vectorizer = joblib.load(BASELINE_MODEL_PATH.parent / "tfidf_vectorizer.joblib")
+            features = prepare_features(frame, vectorizer, fit=False)
+            if hasattr(model, "predict_proba"):
+                probs = model.predict_proba(features)[0]
+                score = float(np.max(probs))
+                pred = model.classes_[int(np.argmax(probs))]
+            else:
+                decision = model.decision_function(features)
+                score = float(1 / (1 + np.exp(-decision[0])))
+                pred = model.predict(features)[0]
+            drift = monitor_drift(float(features.getnnz(axis=1).mean()))
+            attention_terms = "N/A for linear model"
+        else:
+            if not TRANSFORMER_DIR.exists():
+                st.error("Transformer artifacts not found. Run fine-tuning first.")
+                st.stop()
+            tokenizer = AutoTokenizer.from_pretrained(str(TRANSFORMER_DIR))
+            model = AutoModelForSequenceClassification.from_pretrained(str(TRANSFORMER_DIR), output_attentions=True)
+            inputs = tokenizer(text, return_tensors="pt", truncation=True, padding=True)
+            output = model(**inputs)
+            probs = output.logits.softmax(dim=-1).detach().numpy()[0]
+            label_idx = int(np.argmax(probs))
+            pred = model.config.id2label[label_idx]
+            score = float(probs[label_idx])
+            drift = {"psi_proxy": 0.0, "alert": 0}
+            attention = output.attentions[-1].mean(dim=1).detach().numpy()[0]
+            token_ids = inputs["input_ids"][0].tolist()
+            tokens = tokenizer.convert_ids_to_tokens(token_ids)
+            token_scores = attention[0]
+            top_pairs = sorted(zip(tokens, token_scores), key=lambda x: x[1], reverse=True)[:8]
+            attention_terms = ", ".join([f"{t}:{s:.2f}" for t, s in top_pairs])
+
+        risk_flag = int(score >= confidence_threshold)
+        st.subheader("Prediction")
+        st.write(f"**Class:** {pred}")
+        st.write(f"**Confidence:** {score:.3f}")
+        st.write(f"**Risk alert:** {'Yes' if risk_flag else 'No'}")
+        st.write(f"**Drift monitor PSI proxy:** {drift['psi_proxy']:.3f} ({'alert' if drift['alert'] else 'normal'})")
+        st.write(f"**Influential terms / attention:** {attention_terms}")
+
+        secure_log(
+            {
+                "timestamp": datetime.utcnow().isoformat(),
+                "user_hash": hashlib.sha256(user_id.encode()).hexdigest()[:12],
+                "prediction": pred,
+                "confidence": score,
+                "risk_flag": risk_flag,
+                "model": model_choice,
+            }
+        )
+        st.success("Prediction logged locally with hashed user identifier.")

--- a/mental_health_risk_app/data/sample_mental_health.csv
+++ b/mental_health_risk_app/data/sample_mental_health.csv
@@ -1,0 +1,11 @@
+text,label,user_id,timestamp,group
+I feel hopeless and exhausted every day,depression,u1,2025-01-01,group_a
+Panic attacks keep happening and I cannot sleep,stress,u2,2025-01-02,group_b
+Today I feel better and hopeful,low_risk,u3,2025-01-03,group_a
+I am overwhelmed with deadlines and constant anxiety,stress,u2,2025-01-04,group_b
+Nothing matters anymore and I feel empty,depression,u1,2025-01-05,group_a
+Had a calm day and enjoyed a walk,low_risk,u4,2025-01-06,group_c
+I hate myself and feel alone,depression,u5,2025-01-07,group_b
+Work pressure is making me nervous all the time,stress,u6,2025-01-08,group_c
+Grateful for support from friends today,low_risk,u7,2025-01-09,group_a
+My thoughts are dark and I am very tired,depression,u1,2025-01-10,group_a

--- a/mental_health_risk_app/requirements.txt
+++ b/mental_health_risk_app/requirements.txt
@@ -1,0 +1,14 @@
+pandas
+numpy
+scikit-learn
+imbalanced-learn
+nltk
+streamlit
+joblib
+matplotlib
+seaborn
+shap
+torch
+transformers
+datasets
+accelerate

--- a/mental_health_risk_app/src/analysis.py
+++ b/mental_health_risk_app/src/analysis.py
@@ -1,0 +1,67 @@
+import json
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+import shap
+from sklearn.metrics import recall_score
+
+from .config import GROUP_COLUMN, LABEL_COLUMN, REFERENCE_STATS_PATH, TEXT_COLUMN, USER_ID_COLUMN, TIMESTAMP_COLUMN
+from .modeling import AUX_FEATURES, prepare_features
+
+
+def shap_top_tokens(model, vectorizer, df: pd.DataFrame, sample_size: int = 50) -> Dict[str, List[float]]:
+    sample = df.head(sample_size)
+    x_sample = prepare_features(sample, vectorizer, fit=False)
+    explainer = shap.LinearExplainer(model, x_sample, feature_perturbation="interventional")
+    values = explainer.shap_values(x_sample)
+    token_names = vectorizer.get_feature_names_out().tolist() + AUX_FEATURES
+    mean_abs = np.abs(values).mean(axis=0)
+    top_idx = np.argsort(mean_abs)[-20:][::-1]
+    return {token_names[i]: float(mean_abs[i]) for i in top_idx}
+
+
+def fairness_analysis(y_true: np.ndarray, y_pred: np.ndarray, groups: pd.Series) -> Dict[str, Dict[str, float]]:
+    frame = pd.DataFrame({"y_true": y_true, "y_pred": y_pred, "group": groups})
+    output = {}
+    for grp, sub in frame.groupby("group"):
+        output[str(grp)] = {
+            "recall": float(recall_score(sub["y_true"], sub["y_pred"], average="weighted", zero_division=0)),
+            "sample_size": int(len(sub)),
+        }
+    recalls = [v["recall"] for v in output.values()]
+    if recalls:
+        output["summary"] = {"recall_gap": float(max(recalls) - min(recalls))}
+    return output
+
+
+def temporal_trend(df: pd.DataFrame, prediction_scores: np.ndarray) -> pd.DataFrame:
+    if TIMESTAMP_COLUMN not in df.columns:
+        return pd.DataFrame()
+    frame = df[[USER_ID_COLUMN, TIMESTAMP_COLUMN]].copy()
+    frame["risk_score"] = prediction_scores
+    frame = frame.dropna(subset=[TIMESTAMP_COLUMN]).sort_values([USER_ID_COLUMN, TIMESTAMP_COLUMN])
+    frame["rolling_risk"] = frame.groupby(USER_ID_COLUMN)["risk_score"].transform(lambda s: s.ewm(span=3).mean())
+    frame["risk_delta"] = frame.groupby(USER_ID_COLUMN)["rolling_risk"].diff().fillna(0)
+    return frame
+
+
+def psi_score(expected: np.ndarray, actual: np.ndarray, bins: int = 10) -> float:
+    quantiles = np.linspace(0, 1, bins + 1)
+    breakpoints = np.quantile(expected, quantiles)
+    expected_hist = np.histogram(expected, bins=breakpoints)[0] / len(expected)
+    actual_hist = np.histogram(actual, bins=breakpoints)[0] / max(1, len(actual))
+    expected_hist = np.where(expected_hist == 0, 1e-6, expected_hist)
+    actual_hist = np.where(actual_hist == 0, 1e-6, actual_hist)
+    return float(np.sum((actual_hist - expected_hist) * np.log(actual_hist / expected_hist)))
+
+
+def monitor_drift(current_non_zero_mean: float) -> Dict[str, float]:
+    if not REFERENCE_STATS_PATH.exists():
+        return {"psi_proxy": 0.0, "alert": 0}
+    stats = json.loads(REFERENCE_STATS_PATH.read_text())
+    reference_value = stats["tfidf_non_zero_mean"]
+    arr_ref = np.repeat(reference_value, 30)
+    arr_cur = np.repeat(current_non_zero_mean, 30)
+    psi = psi_score(arr_ref, arr_cur)
+    return {"psi_proxy": psi, "alert": int(psi > 0.25)}

--- a/mental_health_risk_app/src/config.py
+++ b/mental_health_risk_app/src/config.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+ARTIFACT_DIR = BASE_DIR / "artifacts"
+LOG_DIR = BASE_DIR / "logs"
+DATA_DIR = BASE_DIR / "data"
+
+BASELINE_MODEL_PATH = ARTIFACT_DIR / "baseline_model.joblib"
+VECTORIZER_PATH = ARTIFACT_DIR / "tfidf_vectorizer.joblib"
+TRANSFORMER_DIR = ARTIFACT_DIR / "transformer_model"
+REFERENCE_STATS_PATH = ARTIFACT_DIR / "reference_stats.json"
+PREDICTION_LOG_PATH = LOG_DIR / "prediction_log.csv"
+
+TEXT_COLUMN = "text"
+LABEL_COLUMN = "label"
+USER_ID_COLUMN = "user_id"
+TIMESTAMP_COLUMN = "timestamp"
+GROUP_COLUMN = "group"

--- a/mental_health_risk_app/src/modeling.py
+++ b/mental_health_risk_app/src/modeling.py
@@ -1,0 +1,98 @@
+import json
+from pathlib import Path
+from typing import Dict, Tuple
+
+import joblib
+import numpy as np
+import pandas as pd
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import (
+    classification_report,
+    confusion_matrix,
+    f1_score,
+    precision_score,
+    recall_score,
+    roc_auc_score,
+)
+from sklearn.svm import LinearSVC
+from sklearn.utils.class_weight import compute_class_weight
+from scipy.sparse import csr_matrix, hstack
+
+from .config import BASELINE_MODEL_PATH, LABEL_COLUMN, REFERENCE_STATS_PATH, TEXT_COLUMN, VECTORIZER_PATH
+
+AUX_FEATURES = [
+    "sent_neg",
+    "sent_neu",
+    "sent_pos",
+    "sent_compound",
+    "emo_sadness",
+    "emo_anxiety",
+    "emo_anger",
+    "emo_joy",
+]
+
+
+def build_tfidf_vectorizer() -> TfidfVectorizer:
+    return TfidfVectorizer(ngram_range=(1, 2), min_df=2, max_df=0.95, max_features=30000)
+
+
+def prepare_features(df: pd.DataFrame, vectorizer: TfidfVectorizer, fit: bool = False) -> csr_matrix:
+    text = df[TEXT_COLUMN].fillna("")
+    x_text = vectorizer.fit_transform(text) if fit else vectorizer.transform(text)
+    aux = df.reindex(columns=AUX_FEATURES, fill_value=0.0).astype(float)
+    x_aux = csr_matrix(aux.values)
+    return hstack([x_text, x_aux])
+
+
+def train_baseline(df_train: pd.DataFrame, model_type: str = "logreg"):
+    vectorizer = build_tfidf_vectorizer()
+    x_train = prepare_features(df_train, vectorizer, fit=True)
+    y_train = df_train[LABEL_COLUMN].values
+
+    classes = np.unique(y_train)
+    weights = compute_class_weight(class_weight="balanced", classes=classes, y=y_train)
+    class_weight = dict(zip(classes, weights))
+
+    if model_type == "svm":
+        model = LinearSVC(class_weight=class_weight)
+    else:
+        model = LogisticRegression(max_iter=300, class_weight=class_weight)
+
+    model.fit(x_train, y_train)
+    BASELINE_MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(model, BASELINE_MODEL_PATH)
+    joblib.dump(vectorizer, VECTORIZER_PATH)
+
+    reference_stats = {
+        "tfidf_non_zero_mean": float(x_train.getnnz(axis=1).mean()),
+        "aux_feature_mean": df_train.reindex(columns=AUX_FEATURES, fill_value=0.0).mean().to_dict(),
+    }
+    REFERENCE_STATS_PATH.write_text(json.dumps(reference_stats, indent=2))
+    return model, vectorizer
+
+
+def load_baseline() -> Tuple[object, TfidfVectorizer]:
+    return joblib.load(BASELINE_MODEL_PATH), joblib.load(VECTORIZER_PATH)
+
+
+def evaluate_model(model, vectorizer, df_eval: pd.DataFrame) -> Dict[str, object]:
+    x_eval = prepare_features(df_eval, vectorizer, fit=False)
+    y_true = df_eval[LABEL_COLUMN].values
+    y_pred = model.predict(x_eval)
+
+    if hasattr(model, "predict_proba"):
+        y_scores = model.predict_proba(x_eval)
+        roc_auc = roc_auc_score(y_true, y_scores[:, 1]) if y_scores.shape[1] == 2 else roc_auc_score(y_true, y_scores, multi_class="ovr")
+    else:
+        decision = model.decision_function(x_eval)
+        roc_auc = roc_auc_score(y_true, decision)
+
+    return {
+        "precision": precision_score(y_true, y_pred, average="weighted", zero_division=0),
+        "recall": recall_score(y_true, y_pred, average="weighted", zero_division=0),
+        "f1": f1_score(y_true, y_pred, average="weighted", zero_division=0),
+        "roc_auc": roc_auc,
+        "confusion_matrix": confusion_matrix(y_true, y_pred).tolist(),
+        "classification_report": classification_report(y_true, y_pred, zero_division=0),
+    }

--- a/mental_health_risk_app/src/preprocess.py
+++ b/mental_health_risk_app/src/preprocess.py
@@ -1,0 +1,105 @@
+import re
+import string
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from nltk.sentiment import SentimentIntensityAnalyzer
+from sklearn.model_selection import train_test_split
+
+from .config import (
+    GROUP_COLUMN,
+    LABEL_COLUMN,
+    TEXT_COLUMN,
+    TIMESTAMP_COLUMN,
+    USER_ID_COLUMN,
+)
+
+URL_PATTERN = re.compile(r"https?://\S+|www\.\S+")
+MENTION_PATTERN = re.compile(r"@\w+")
+WHITESPACE_PATTERN = re.compile(r"\s+")
+
+
+@dataclass
+class DatasetBundle:
+    train: pd.DataFrame
+    val: pd.DataFrame
+    test: pd.DataFrame
+
+
+def clean_text(text: str) -> str:
+    text = text.lower()
+    text = URL_PATTERN.sub(" ", text)
+    text = MENTION_PATTERN.sub(" ", text)
+    text = text.translate(str.maketrans("", "", string.punctuation))
+    text = WHITESPACE_PATTERN.sub(" ", text).strip()
+    return text
+
+
+def add_sentiment_features(df: pd.DataFrame) -> pd.DataFrame:
+    sia = SentimentIntensityAnalyzer()
+    sentiments = df[TEXT_COLUMN].fillna("").apply(sia.polarity_scores)
+    df = df.copy()
+    for col in ["neg", "neu", "pos", "compound"]:
+        df[f"sent_{col}"] = sentiments.apply(lambda x: x[col])
+    return df
+
+
+def add_emotion_proxy_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Simple lexicon proxies; replace with richer emotion model if available."""
+    emotion_lexicon = {
+        "sadness": {"sad", "empty", "hopeless", "down", "tired", "alone"},
+        "anxiety": {"anxious", "panic", "worry", "nervous", "stress", "overwhelmed"},
+        "anger": {"angry", "furious", "irritated", "hate"},
+        "joy": {"happy", "grateful", "hopeful", "calm", "better"},
+    }
+    df = df.copy()
+    tokens = df[TEXT_COLUMN].fillna("").str.split()
+    for emotion, words in emotion_lexicon.items():
+        df[f"emo_{emotion}"] = tokens.apply(lambda tok: sum(1 for t in tok if t in words))
+    return df
+
+
+def preprocess_frame(df: pd.DataFrame) -> pd.DataFrame:
+    if TEXT_COLUMN not in df.columns or LABEL_COLUMN not in df.columns:
+        raise ValueError(f"Input data must include '{TEXT_COLUMN}' and '{LABEL_COLUMN}' columns")
+
+    df = df.copy()
+    df[TEXT_COLUMN] = df[TEXT_COLUMN].fillna("").apply(clean_text)
+    if TIMESTAMP_COLUMN in df.columns:
+        df[TIMESTAMP_COLUMN] = pd.to_datetime(df[TIMESTAMP_COLUMN], errors="coerce")
+    if USER_ID_COLUMN not in df.columns:
+        df[USER_ID_COLUMN] = "anonymous"
+    if GROUP_COLUMN not in df.columns:
+        df[GROUP_COLUMN] = "unknown"
+
+    df = add_sentiment_features(df)
+    df = add_emotion_proxy_features(df)
+    return df
+
+
+def split_dataset(
+    df: pd.DataFrame,
+    test_size: float = 0.15,
+    val_size: float = 0.15,
+    random_state: int = 42,
+    stratify: bool = True,
+) -> DatasetBundle:
+    strat = df[LABEL_COLUMN] if stratify else None
+    train_val, test = train_test_split(
+        df, test_size=test_size, random_state=random_state, stratify=strat
+    )
+    strat_tv = train_val[LABEL_COLUMN] if stratify else None
+    val_ratio = val_size / (1 - test_size)
+    train, val = train_test_split(
+        train_val, test_size=val_ratio, random_state=random_state, stratify=strat_tv
+    )
+    return DatasetBundle(train=train.reset_index(drop=True), val=val.reset_index(drop=True), test=test.reset_index(drop=True))
+
+
+def handle_class_imbalance(labels: pd.Series) -> dict:
+    counts = labels.value_counts().to_dict()
+    total = len(labels)
+    num_classes = len(counts)
+    return {klass: total / (num_classes * count) for klass, count in counts.items()}

--- a/mental_health_risk_app/src/transformer_pipeline.py
+++ b/mental_health_risk_app/src/transformer_pipeline.py
@@ -1,0 +1,83 @@
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+from datasets import Dataset
+from sklearn.metrics import precision_recall_fscore_support, roc_auc_score
+from transformers import (
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    Trainer,
+    TrainingArguments,
+)
+
+from .config import LABEL_COLUMN, TEXT_COLUMN, TRANSFORMER_DIR
+
+
+MODEL_NAME = "distilbert-base-uncased"
+
+
+def _tokenize(tokenizer, batch):
+    return tokenizer(batch[TEXT_COLUMN], truncation=True, padding="max_length", max_length=128)
+
+
+def _metrics(eval_pred) -> Dict[str, float]:
+    logits, labels = eval_pred
+    probs = np.exp(logits) / np.exp(logits).sum(axis=1, keepdims=True)
+    preds = probs.argmax(axis=1)
+    precision, recall, f1, _ = precision_recall_fscore_support(labels, preds, average="weighted", zero_division=0)
+    if probs.shape[1] == 2:
+        roc_auc = roc_auc_score(labels, probs[:, 1])
+    else:
+        roc_auc = roc_auc_score(labels, probs, multi_class="ovr")
+    return {
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "roc_auc": roc_auc,
+    }
+
+
+def fine_tune_transformer(train_df: pd.DataFrame, val_df: pd.DataFrame, label2id: Dict[str, int]):
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    num_labels = len(label2id)
+    id2label = {v: k for k, v in label2id.items()}
+
+    for df in [train_df, val_df]:
+        df[LABEL_COLUMN] = df[LABEL_COLUMN].map(label2id)
+
+    train_ds = Dataset.from_pandas(train_df[[TEXT_COLUMN, LABEL_COLUMN]])
+    val_ds = Dataset.from_pandas(val_df[[TEXT_COLUMN, LABEL_COLUMN]])
+
+    train_ds = train_ds.map(lambda x: _tokenize(tokenizer, x), batched=True)
+    val_ds = val_ds.map(lambda x: _tokenize(tokenizer, x), batched=True)
+
+    model = AutoModelForSequenceClassification.from_pretrained(
+        MODEL_NAME, num_labels=num_labels, label2id=label2id, id2label=id2label
+    )
+
+    args = TrainingArguments(
+        output_dir=str(TRANSFORMER_DIR),
+        evaluation_strategy="epoch",
+        save_strategy="epoch",
+        learning_rate=2e-5,
+        per_device_train_batch_size=16,
+        per_device_eval_batch_size=16,
+        num_train_epochs=2,
+        weight_decay=0.01,
+        load_best_model_at_end=True,
+        metric_for_best_model="f1",
+        report_to="none",
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=args,
+        train_dataset=train_ds,
+        eval_dataset=val_ds,
+        tokenizer=tokenizer,
+        compute_metrics=_metrics,
+    )
+    trainer.train()
+    trainer.save_model(str(TRANSFORMER_DIR))
+    tokenizer.save_pretrained(str(TRANSFORMER_DIR))

--- a/mental_health_risk_app/train.py
+++ b/mental_health_risk_app/train.py
@@ -1,0 +1,68 @@
+import argparse
+import json
+
+import nltk
+import pandas as pd
+
+from src.analysis import fairness_analysis, shap_top_tokens, temporal_trend
+from src.config import GROUP_COLUMN, LABEL_COLUMN, TEXT_COLUMN
+from src.modeling import evaluate_model, load_baseline, prepare_features, train_baseline
+from src.preprocess import preprocess_frame, split_dataset
+from src.transformer_pipeline import fine_tune_transformer
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--data", required=True, help="Path to labeled csv with text,label columns")
+    p.add_argument("--baseline", choices=["logreg", "svm"], default="logreg")
+    p.add_argument("--train-transformer", action="store_true")
+    p.add_argument("--output", default="mental_health_risk_app/artifacts/metrics.json")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    nltk.download("vader_lexicon", quiet=True)
+
+    df = pd.read_csv(args.data)
+    df = preprocess_frame(df)
+    bundle = split_dataset(df)
+
+    model, vectorizer = train_baseline(bundle.train, args.baseline)
+    metrics = evaluate_model(model, vectorizer, bundle.test)
+
+    x_test = prepare_features(bundle.test, vectorizer, fit=False)
+    y_pred = model.predict(x_test)
+    fairness = fairness_analysis(bundle.test[LABEL_COLUMN].values, y_pred, bundle.test[GROUP_COLUMN])
+    shap_terms = shap_top_tokens(model, vectorizer, bundle.test)
+
+    if hasattr(model, "predict_proba"):
+        risk_scores = model.predict_proba(x_test)
+        risk_series = risk_scores[:, 1] if risk_scores.shape[1] == 2 else risk_scores.max(axis=1)
+    else:
+        decision = model.decision_function(x_test)
+        risk_series = 1 / (1 + pow(2.71828, -decision))
+
+    temporal = temporal_trend(bundle.test, risk_series)
+
+    output = {
+        "baseline_metrics": metrics,
+        "fairness": fairness,
+        "top_shap_terms": shap_terms,
+        "temporal_preview": temporal.head(20).to_dict(orient="records"),
+        "ethics_disclaimer": "Not a diagnostic tool. Use only for supportive triage and human review.",
+    }
+
+    if args.train_transformer:
+        labels = sorted(df[LABEL_COLUMN].unique().tolist())
+        label2id = {k: i for i, k in enumerate(labels)}
+        fine_tune_transformer(bundle.train.copy(), bundle.val.copy(), label2id)
+        output["transformer"] = "fine_tuned"
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(output, f, indent=2)
+    print(f"Training complete. Metrics saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a self-contained, local-inference pipeline to estimate depression/stress risk from user text while emphasizing ethical safeguards and non-diagnostic disclaimers. 
- Combine classical baselines and transformer fine-tuning plus interpretability, fairness, and drift monitoring to enable practical evaluation and safe local deployment.

### Description
- Add a new `mental_health_risk_app` module containing preprocessing, modeling, transformer fine-tuning, analysis, Streamlit inference app, training orchestration, sample labeled CSV, and `requirements.txt`.
- Implement text preprocessing with `clean_text`, sentiment features (VADER), simple emotion-proxy lexicon features, and stratified `split_dataset`, plus class-imbalance handling utilities in `src/preprocess.py`.
- Implement baseline TF-IDF + auxiliary features pipeline with class-weighted `LogisticRegression`/`LinearSVC`, artifact persistence (model + vectorizer + reference stats), and evaluation metrics (Precision/Recall/F1/ROC-AUC/confusion matrix) in `src/modeling.py`.
- Add a Hugging Face transformer fine-tuning pipeline (`distilbert-base-uncased`) in `src/transformer_pipeline.py`, SHAP-based token attributions, subgroup fairness recall-gap checks, temporal per-user trend computation, and a PSI-style drift proxy in `src/analysis.py`.
- Provide a local Streamlit app (`app.py`) that performs secured local logging (hashed user IDs), shows confidence scores, drift status, and attention-term highlights for transformer models, and includes a prominent ethics disclaimer and privacy-minded defaults.

### Testing
- `python -m compileall mental_health_risk_app` ran successfully and all new modules compiled without syntax errors (success).
- `python mental_health_risk_app/train.py --data mental_health_risk_app/data/sample_mental_health.csv --baseline logreg` was attempted but failed in this environment due to missing runtime dependencies (failed: `ModuleNotFoundError: No module named 'nltk'`).
- `pip install -r mental_health_risk_app/requirements.txt` was attempted but could not complete because the environment could not reach the package index (network/proxy restrictions) so dependencies were not installed (failed).
- `streamlit --version` and a headless browser screenshot attempt were attempted but did not succeed because Streamlit and app dependencies were not available and the app was not running (no screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698acb56b07c832da40e1fd9ba03946d)